### PR TITLE
Several improvements to no-module-imports

### DIFF
--- a/docs/rules/no-module-imports.md
+++ b/docs/rules/no-module-imports.md
@@ -12,11 +12,18 @@ command line.
 
 Possible configurations:
 
-- `"always"`: disallow importing any member from a module. This is the default
-  value.
-- `"allow-types"`: allow importing type members from a module.
+_`allowTypes`_ (boolean)
 
-Example of **incorrect** code for this rule, when configured as `always`:
+- `false`: disallow importing any member from a module. This is the default
+  value.
+- `true`: allow importing type members from a module.
+
+_`allowedModules`_ (string[])
+
+List of allowed modules, defaults to `["function", "pipeable"]`.
+
+Example of **incorrect** code for this rule, when configured with
+`{ allowTypes: false }`
 
 ```ts
 import { Option, some } from "fp-ts/Option";
@@ -24,15 +31,8 @@ import { Option, some } from "fp-ts/Option";
 const x: Option<number> = some(42);
 ```
 
-Example of **incorrect** code for this rule, when configured as `allow-types`:
-
-```ts
-import { some } from "fp-ts/Option";
-
-const x = some(42);
-```
-
-Example of **correct** code for this rule, when configured as `always`:
+Example of **correct** code for this rule, when configured with
+`{ allowTypes: false }`:
 
 ```ts
 import { option } from "fp-ts";
@@ -40,11 +40,21 @@ import { option } from "fp-ts";
 const x: option.Option<number> = option.some(42);
 ```
 
-Example of **correct** code for this rule, when configured as `allow-types`:
+Example of **correct** code for this rule, when configured with
+`{ allowTypes: true }`
 
 ```ts
 import { option } from "fp-ts";
 import { Option } from "fp-ts/Option";
 
 const x: Option<number> = option.some(42);
+```
+
+Example of **correct** code for this rule, when configured with
+`{ allowedModules: ["Option"] }`:
+
+```ts
+import { Option, some } from "fp-ts/Option";
+
+const x: Option<number> = some(42);
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { pipe } from "fp-ts/function";
 const potentialErrors = {
   "no-lib-imports": require("./rules/no-lib-imports"),
   "no-pipeable": require("./rules/no-pipeable"),
-  "no-module-imports": require("./rules/no-module-imports"),
+  "no-module-imports": require("./rules/no-module-imports").default,
 };
 
 const suggestions = {

--- a/src/rules/no-module-imports.ts
+++ b/src/rules/no-module-imports.ts
@@ -1,151 +1,166 @@
 import {
   ASTUtils,
   AST_NODE_TYPES,
-  TSESLint,
 } from "@typescript-eslint/experimental-utils";
 import { array } from "fp-ts";
 import { pipe } from "fp-ts/function";
-import { contextUtils } from "../utils";
+import { contextUtils, createRule } from "../utils";
+
+type Options = [{ allowTypes?: boolean; allowedModules?: string[] }];
 
 const messages = {
   importNotAllowed:
     "Importing from modules is not allowed, import from 'fp-ts' instead",
   importValuesNotAllowed:
     "Importing values from modules is not allowed, import from 'fp-ts' instead",
-  convertImportToIndex: "Import all members from fp-ts",
-  convertImportValuesToIndex: "Import values from fp-ts",
 } as const;
 type MessageIds = keyof typeof messages;
 
-type Options = ["always" | "allow-types"];
-
-export const meta: TSESLint.RuleMetaData<MessageIds> = {
-  type: "suggestion",
-  fixable: "code",
-  schema: [
-    {
-      enum: ["always", "allow-types"],
+export default createRule<Options, MessageIds>({
+  name: "no-module-imports",
+  meta: {
+    type: "problem",
+    fixable: "code",
+    docs: {
+      category: "Best Practices",
+      description:
+        "Disallow imports from fp-ts modules, such as `fp-ts/Option`",
+      recommended: "error",
     },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allowTypes: {
+            type: "boolean",
+          },
+          allowedModules: {
+            type: "array",
+            items: {
+              type: "string",
+            },
+          },
+        },
+      },
+    ],
+    messages: {
+      importNotAllowed:
+        "Importing from modules is not allowed, import from 'fp-ts' instead",
+      importValuesNotAllowed:
+        "Importing values from modules is not allowed, import from 'fp-ts' instead",
+    },
+  },
+  defaultOptions: [
+    { allowedModules: ["function", "pipeable"], allowTypes: false },
   ],
-  messages,
-};
+  create(context, [options]) {
+    const allowTypes = options.allowTypes;
+    const allowedModules = options.allowedModules ?? [];
 
-export function create(
-  context: TSESLint.RuleContext<MessageIds, Options>
-): TSESLint.RuleListener {
-  const allowTypes = context.options[0] === "allow-types";
-  const allowedModules = ["function"];
+    const {
+      addNamedImportIfNeeded,
+      isOnlyUsedAsType,
+      removeImportDeclaration,
+    } = contextUtils(context);
 
-  const {
-    addNamedImportIfNeeded,
-    isOnlyUsedAsType,
-    removeImportDeclaration,
-  } = contextUtils(context);
+    return {
+      ImportDeclaration(node) {
+        const sourceValue = node.source.value?.toString();
+        if (sourceValue) {
+          const forbiddenImportPattern = /^fp-ts\/(.+)/;
+          const matches = sourceValue.match(forbiddenImportPattern);
 
-  return {
-    ImportDeclaration(node) {
-      const sourceValue = node.source.value?.toString();
-      if (sourceValue) {
-        const forbiddenImportPattern = /^fp-ts\/(.+)/;
-        const matches = sourceValue.match(forbiddenImportPattern);
+          if (matches != null) {
+            const matchedModule = matches[1]!.replace("lib/", "");
+            if (allowedModules.includes(matchedModule)) {
+              return;
+            }
 
-        if (matches != null) {
-          const matchedModule = matches[1]!.replace("lib/", "");
-          if (allowedModules.includes(matchedModule)) {
-            return;
-          }
+            const importSpecifiers = node.specifiers.filter(
+              (importClause) =>
+                importClause.type === AST_NODE_TYPES.ImportSpecifier
+            );
 
-          const importSpecifiers = node.specifiers.filter(
-            (importClause) =>
-              importClause.type === AST_NODE_TYPES.ImportSpecifier
-          );
+            const nonTypeImports = pipe(
+              importSpecifiers,
+              array.filter((i) => !isOnlyUsedAsType(i))
+            );
 
-          const nonTypeImports = pipe(
-            importSpecifiers,
-            array.filter((i) => !isOnlyUsedAsType(i))
-          );
+            if (allowTypes && nonTypeImports.length === 0) {
+              return;
+            }
 
-          if (allowTypes && nonTypeImports.length === 0) {
-            return;
-          }
+            if (importSpecifiers.length > 0) {
+              context.report({
+                node: node.source,
+                messageId: allowTypes
+                  ? "importValuesNotAllowed"
+                  : "importNotAllowed",
+                fix(fixer) {
+                  const indexExport =
+                    matchedModule.charAt(0).toLowerCase() +
+                    matchedModule.slice(1);
 
-          if (importSpecifiers.length > 0) {
-            context.report({
-              node: node.source,
-              messageId: allowTypes
-                ? "importValuesNotAllowed"
-                : "importNotAllowed",
-              suggest: [
-                {
-                  messageId: allowTypes
-                    ? "convertImportValuesToIndex"
-                    : "convertImportToIndex",
-                  fix(fixer) {
-                    const indexExport =
-                      matchedModule.charAt(0).toLowerCase() +
-                      matchedModule.slice(1);
-
-                    const referencesFixes = importSpecifiers.flatMap(
-                      (importSpecifier) => {
-                        const variable = ASTUtils.findVariable(
-                          context.getScope(),
-                          importSpecifier.local.name
-                        );
-                        if (variable) {
-                          return variable.references
-                            .filter((ref) =>
-                              allowTypes
-                                ? ref.identifier.parent?.type !==
-                                  AST_NODE_TYPES.TSTypeReference
-                                : true
+                  const referencesFixes = importSpecifiers.flatMap(
+                    (importSpecifier) => {
+                      const variable = ASTUtils.findVariable(
+                        context.getScope(),
+                        importSpecifier.local.name
+                      );
+                      if (variable) {
+                        return variable.references
+                          .filter((ref) =>
+                            allowTypes
+                              ? ref.identifier.parent?.type !==
+                                AST_NODE_TYPES.TSTypeReference
+                              : true
+                          )
+                          .filter(
+                            (ref) =>
+                              ref.identifier.parent?.type !==
+                              AST_NODE_TYPES.MemberExpression
+                          )
+                          .map((ref) =>
+                            fixer.insertTextBefore(
+                              ref.identifier,
+                              `${indexExport}.`
                             )
-                            .filter(
-                              (ref) =>
-                                ref.identifier.parent?.type !==
-                                AST_NODE_TYPES.MemberExpression
-                            )
-                            .map((ref) =>
-                              fixer.insertTextBefore(
-                                ref.identifier,
-                                `${indexExport}.`
-                              )
-                            );
-                        } else {
-                          return [];
-                        }
+                          );
+                      } else {
+                        return [];
                       }
-                    );
+                    }
+                  );
 
-                    const importFixes =
-                      !allowTypes ||
-                      nonTypeImports.length === importSpecifiers.length
-                        ? [removeImportDeclaration(node, fixer)]
-                        : nonTypeImports.map((node) => {
-                            if (
-                              context.getSourceCode().getTokenAfter(node)
-                                ?.value === ","
-                            ) {
-                              return fixer.removeRange([
-                                node.range[0],
-                                node.range[1] + 1,
-                              ]);
-                            } else {
-                              return fixer.remove(node);
-                            }
-                          });
+                  const importFixes =
+                    !allowTypes ||
+                    nonTypeImports.length === importSpecifiers.length
+                      ? [removeImportDeclaration(node, fixer)]
+                      : nonTypeImports.map((node) => {
+                          if (
+                            context.getSourceCode().getTokenAfter(node)
+                              ?.value === ","
+                          ) {
+                            return fixer.removeRange([
+                              node.range[0],
+                              node.range[1] + 1,
+                            ]);
+                          } else {
+                            return fixer.remove(node);
+                          }
+                        });
 
-                    return [
-                      ...importFixes,
-                      ...addNamedImportIfNeeded(indexExport, "fp-ts", fixer),
-                      ...referencesFixes,
-                    ];
-                  },
+                  return [
+                    ...importFixes,
+                    ...addNamedImportIfNeeded(indexExport, "fp-ts", fixer),
+                    ...referencesFixes,
+                  ];
                 },
-              ],
-            });
+              });
+            }
           }
         }
-      }
-    },
-  };
-}
+      },
+    };
+  },
+});

--- a/tests/rules/no-module-imports.test.ts
+++ b/tests/rules/no-module-imports.test.ts
@@ -1,4 +1,4 @@
-import * as rule from "../../src/rules/no-module-imports";
+import rule from "../../src/rules/no-module-imports";
 import { ESLintUtils } from "@typescript-eslint/experimental-utils";
 import { stripIndent } from "common-tags";
 
@@ -20,7 +20,13 @@ ruleTester.run("no-module-imports", rule, {
         import { option } from "fp-ts"
         const x: Option<number> = option.some(2)
       `,
-      options: ["allow-types"],
+      options: [{ allowTypes: true }],
+    },
+    {
+      code: stripIndent`
+        import { sequenceS } from "fp-ts/Apply"
+      `,
+      options: [{ allowedModules: ["Apply"] }],
     },
   ],
   invalid: [
@@ -28,24 +34,19 @@ ruleTester.run("no-module-imports", rule, {
       code: stripIndent`
         import { option } from "fp-ts"
         import { Option } from "fp-ts/Option"
+
         const x: Option<number> = option.some(2)
       `,
-      options: ["always"],
       errors: [
         {
           messageId: "importNotAllowed",
-          suggestions: [
-            {
-              messageId: "convertImportToIndex",
-              output: stripIndent`
-                import { option } from "fp-ts"
-
-                const x: option.Option<number> = option.some(2)
-              `,
-            },
-          ],
         },
       ],
+      output: stripIndent`
+        import { option } from "fp-ts"
+
+        const x: option.Option<number> = option.some(2)
+      `,
     },
     {
       code: stripIndent`
@@ -54,24 +55,19 @@ ruleTester.run("no-module-imports", rule, {
         const x: Option<number> = some(2)
         const y: Option<number> = none
       `,
-      options: ["allow-types"],
+      options: [{ allowTypes: true }],
       errors: [
         {
           messageId: "importValuesNotAllowed",
-          suggestions: [
-            {
-              messageId: "convertImportValuesToIndex",
-              output: stripIndent`
-                import {  Option,  } from "fp-ts/Option"
-                import { option } from "fp-ts"
-
-                const x: Option<number> = option.some(2)
-                const y: Option<number> = option.none
-              `,
-            },
-          ],
         },
       ],
+      output: stripIndent`
+        import {  Option,  } from "fp-ts/Option"
+        import { option } from "fp-ts"
+
+        const x: Option<number> = option.some(2)
+        const y: Option<number> = option.none
+      `,
     },
     {
       code: stripIndent`
@@ -82,19 +78,13 @@ ruleTester.run("no-module-imports", rule, {
       errors: [
         {
           messageId: "importNotAllowed",
-          suggestions: [
-            {
-              messageId: "convertImportToIndex",
-              output: [
-                "",
-                'import { option } from "fp-ts"',
-                "",
-                "const x = option.some(2)",
-              ].join("\n"),
-            },
-          ],
         },
       ],
+      output: stripIndent`
+        import { option } from "fp-ts"
+
+        const x = option.some(2)
+      `,
     },
     {
       code: stripIndent`
@@ -105,19 +95,13 @@ ruleTester.run("no-module-imports", rule, {
       errors: [
         {
           messageId: "importNotAllowed",
-          suggestions: [
-            {
-              messageId: "convertImportToIndex",
-              output: [
-                "",
-                'import { option } from "fp-ts"',
-                "",
-                "const v = option.some(42)",
-              ].join("\n"),
-            },
-          ],
         },
       ],
+      output: stripIndent`
+        import { option } from "fp-ts"
+
+        const v = option.some(42)
+      `,
     },
     {
       code: stripIndent`
@@ -131,21 +115,15 @@ ruleTester.run("no-module-imports", rule, {
       errors: [
         {
           messageId: "importNotAllowed",
-          suggestions: [
-            {
-              messageId: "convertImportToIndex",
-              output: stripIndent`
-                import { array, option } from "fp-ts"
-
-
-                const v = option.some(42)
-                const y = option.none
-                const z = option.fromNullable(null)
-              `,
-            },
-          ],
         },
       ],
+      output: stripIndent`
+        import { array, option } from "fp-ts"
+
+        const v = option.some(42)
+        const y = option.none
+        const z = option.fromNullable(null)
+      `,
     },
   ],
 });


### PR DESCRIPTION
- add `allowedModules` option
- pass all options as single configuration option, including `allowTypes`
- (chore) use `RuleCreator` from typescript-eslint to manage default options
- make the rule auto-fixable (instead of a suggestion)
- several improvement to the autofix regarding imports management