### PR TITLE
Respect existing quote type when possible

### DIFF
--- a/src/rules/no-module-imports.ts
+++ b/src/rules/no-module-imports.ts
@@ -4,7 +4,7 @@ import {
 } from "@typescript-eslint/experimental-utils";
 import { array } from "fp-ts";
 import { pipe } from "fp-ts/function";
-import { contextUtils, createRule } from "../utils";
+import { contextUtils, createRule, inferQuote } from "../utils";
 
 type Options = [{ allowTypes?: boolean; allowedModules?: string[] }];
 
@@ -65,7 +65,7 @@ export default createRule<Options, MessageIds>({
 
     return {
       ImportDeclaration(node) {
-        const sourceValue = node.source.value?.toString();
+        const sourceValue = ASTUtils.getStringIfConstant(node.source);
         if (sourceValue) {
           const forbiddenImportPattern = /^fp-ts\/(.+)/;
           const matches = sourceValue.match(forbiddenImportPattern);
@@ -152,7 +152,12 @@ export default createRule<Options, MessageIds>({
 
                   return [
                     ...importFixes,
-                    ...addNamedImportIfNeeded(indexExport, "fp-ts", fixer),
+                    ...addNamedImportIfNeeded(
+                      indexExport,
+                      "fp-ts",
+                      inferQuote(node.source),
+                      fixer
+                    ),
                     ...referencesFixes,
                   ];
                 },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -160,6 +160,11 @@ export function inferIndent(node: TSESTree.Node): string {
   return new Array(node.loc.start.column + 1).join(" ");
 }
 
+type Quote = "'" | '"';
+export function inferQuote(node: TSESTree.Literal): Quote {
+  return node.raw[0] === "'" ? "'" : '"';
+}
+
 export const contextUtils = <
   TMessageIds extends string,
   TOptions extends readonly unknown[]
@@ -201,6 +206,7 @@ export const contextUtils = <
   function addNamedImportIfNeeded(
     name: string,
     moduleName: string,
+    quote: Quote,
     fixer: TSESLint.RuleFixer
   ): Array<TSESLint.RuleFix> {
     return pipe(
@@ -215,7 +221,7 @@ export const contextUtils = <
               () => [
                 fixer.insertTextAfterRange(
                   [0, 0],
-                  `import { ${name} } from "${moduleName}"\n`
+                  `import { ${name} } from ${quote}${moduleName}${quote}\n`
                 ),
               ],
               (lastImport) =>
@@ -223,7 +229,7 @@ export const contextUtils = <
                 [
                   fixer.insertTextAfterRange(
                     [lastImport.range[0], lastImport.range[1] + 1],
-                    `import { ${name} } from "${moduleName}"\n`
+                    `import { ${name} } from ${quote}${moduleName}${quote}\n`
                   ),
                 ]
             )

--- a/tests/rules/no-module-imports.test.ts
+++ b/tests/rules/no-module-imports.test.ts
@@ -125,5 +125,22 @@ ruleTester.run("no-module-imports", rule, {
         const z = option.fromNullable(null)
       `,
     },
+    {
+      code: stripIndent`
+        import { some } from 'fp-ts/Option'
+
+        const v = some(42)
+      `,
+      errors: [
+        {
+          messageId: "importNotAllowed",
+        },
+      ],
+      output: stripIndent`
+        import { option } from 'fp-ts'
+
+        const v = option.some(42)
+      `,
+    },
   ],
 });

--- a/tests/rules/no-pipeable.test.ts
+++ b/tests/rules/no-pipeable.test.ts
@@ -33,6 +33,15 @@ ruleTester.run("no-pipeable", rule, {
       output: 'import { pipe } from "fp-ts/function"',
     },
     {
+      code: "import { pipe } from 'fp-ts/pipeable'",
+      errors: [
+        {
+          messageId: "importPipeFromFunction",
+        },
+      ],
+      output: "import { pipe } from 'fp-ts/function'",
+    },
+    {
       code: 'import { pipeable } from "fp-ts/pipeable"',
       errors: [
         {


### PR DESCRIPTION
As a followup of #35, we now do a best effort attempt at preserving the quote type of imports when adding/replacing them.