### PR TITLE
Fix matching of adjacent combinators

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,6 +77,14 @@ export function getAdjacentCombinators<
   combinator2: CombinatorQuery<N2["type"]>,
   requireMatchingPrefix: boolean
 ): option.Option<[N1, N2]> {
+  function matches(value: string, stringOrRegex: string | RegExp): boolean {
+    if (typeof stringOrRegex === "string") {
+      return value === stringOrRegex;
+    } else {
+      return !!value.match(stringOrRegex);
+    }
+  }
+
   const firstCombinatorIndex = pipeOrFlowExpression.arguments.findIndex(
     (a, index) => {
       if (
@@ -92,8 +100,8 @@ export function getAdjacentCombinators<
             }),
             option.exists(
               ({ idA, idB }) =>
-                !!idA.name.match(combinator1.name) &&
-                !!idB.name.match(combinator2.name)
+                matches(idA.name, combinator1.name) &&
+                matches(idB.name, combinator2.name)
             )
           );
         }

--- a/tests/rules/prefer-bimap.test.ts
+++ b/tests/rules/prefer-bimap.test.ts
@@ -19,6 +19,18 @@ ruleTester.run("prefer-bimap", rule, {
         )
       `,
     },
+    {
+      code: stripIndent`
+        import { either } from "fp-ts"
+        import { pipe } from "fp-ts/function"
+
+        pipe(
+          getResult(),
+          either.mapLeft(e => e.toString()),
+          either.mapLeft(e => e.toString()),
+        )
+      `,
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Fixes #47 

We were using `.match` even when the test value was a `string`, where instead we wanted perform an exact match in that case.

This was causing `mapLeft` + `map` to also match `mapLeft` + `mapLeft` since `"mapLeft".match("map")` would return `true`.