### PR TITLE
fix import fixer

### DIFF
--- a/tests/rules/no-pipeable.test.ts
+++ b/tests/rules/no-pipeable.test.ts
@@ -21,7 +21,8 @@ ruleTester.run("no-pipeable", rule, {
           messageId: "importPipeFromFunction",
         },
       ],
-      output: 'import { pipe } from "fp-ts/function"',
+      output: `import { pipe } from "fp-ts/function"
+`,
     },
     {
       code: 'import { pipe } from "fp-ts/pipeable"',
@@ -30,7 +31,8 @@ ruleTester.run("no-pipeable", rule, {
           messageId: "importPipeFromFunction",
         },
       ],
-      output: 'import { pipe } from "fp-ts/function"',
+      output: `import { pipe } from "fp-ts/function"
+`,
     },
     {
       code: "import { pipe } from 'fp-ts/pipeable'",
@@ -39,7 +41,8 @@ ruleTester.run("no-pipeable", rule, {
           messageId: "importPipeFromFunction",
         },
       ],
-      output: "import { pipe } from 'fp-ts/function'",
+      output: `import { pipe } from 'fp-ts/function'
+`,
     },
     {
       code: 'import { pipeable } from "fp-ts/pipeable"',


### PR DESCRIPTION
Thank you for watching PR!
I fixed bug in `no-pipeable`

## error code

```ts
import { identity } from 'fp-ts/function';
import { pipe } from 'fp-ts/pipeable';
```

result to

```ts
import { identity } from 'fp-ts/function';
import { pipe } from 'fp-ts/function';
```

## expect

```ts
import { identity, pipe } from 'fp-ts/function';
```
