### PR TITLE
Make package compliant to new plugin definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,39 +19,59 @@ npm install --save-dev eslint-plugin-fp-ts
 yarn add --dev eslint-plugin-fp-ts
 ```
 
-Then enable the plugin in your `.eslintrc` config
+Then enable the plugin in your `eslint.config.mjs` file
 
-```json
-{
-  "plugins": ["fp-ts"]
-}
+```js
+import {defineConfig} from 'eslint/config'
+import fptsPlugin from 'eslint-plugin-fp-ts'
+
+export default defineConfig(
+  {
+    plugins: {
+      'fp-ts': fptsPlugin,
+    }
+  }
+)
 ```
 
 and enable the rules you want, for example
 
-```json
-{
-  "plugins": ["fp-ts"],
-  "rules": {
-    "fp-ts/no-lib-imports": "error"
+```js
+export default defineConfig(
+  {
+    plugins: {
+      'fp-ts': fptsPlugin,
+    },
+
+    rules: {
+      "fp-ts/no-lib-imports": "error"
+    }
   }
-}
+)
 ```
 
 If you want to enable rules that require type information (see the table below),
 then you will also need to add some extra info:
 
 ```js
-module.exports = {
-  plugins: ["fp-ts"],
-  parserOptions: {
-    tsconfigRootDir: __dirname,
-    project: ["./tsconfig.json"],
-  },
-  rules: {
-    "fp-ts/no-discarded-pure-expression": "error",
-  },
-};
+export default defineConfig(
+  {
+    plugins: {
+      'fp-ts': fptsPlugin,
+    },
+
+    languageOptions: {
+      parserOptions: {
+        projectService: true,
+        tsconfigRootDir: import.meta.dirname
+      }
+    },
+
+    rules: {
+      "fp-ts/no-discarded-pure-expression": "error",
+    }
+  }
+)
 ```
 
 If your project is a multi-package monorepo, you can follow the instructions
@@ -87,12 +107,18 @@ If your project is a multi-package monorepo, you can follow the instructions
 
 The plugin defines a `recommended` configuration with some reasonable defaults.
 
-To use it, add it to the `extends` clause of your `.eslintrc` file:
+To use it, add it to the `extends` clause of your `eslint.config.mjs` file:
 
-```json
-{
-  "extends": ["plugin:fp-ts/recommended"]
-}
+```js
+export default defineConfig(
+  {
+    plugins: {
+      'fp-ts': fptsPlugin,
+    },
+
+    extends: ["plugin:fp-ts/recommended"]
+  }
+)
 ```
 
 The rules included in this configuration are:
@@ -107,13 +133,19 @@ recommended rules which require type information.
 
 This configuration needs to be included _in addition_ to the `recommended` one:
 
-```
-{
-  "extends": [
-    "plugin:fp-ts/recommended",
-    "plugin:fp-ts/recommended-requiring-type-checking"
-  ]
-}
+```js
+export default defineConfig(
+  {
+    plugins: {
+      'fp-ts': fptsPlugin,
+    },
+
+    extends: [
+      "fp-ts/recommended",
+      "fp-ts/recommended-requiring-type-checking"
+    ]
+  }
+)
 ```
 
 > 👉 You can read more about linting with type information, including
@@ -125,10 +157,16 @@ This configuration needs to be included _in addition_ to the `recommended` one:
 The plugin also defines an `all` configuration which includes every available
 rule.
 
-To use it, add it to the `extends` clause of your `.eslintrc` file:
+To use it, add it to the `extends` clause of your `eslint.config.mjs` file:
 
-```json
-{
-  "extends": ["plugin:fp-ts/all"]
-}
+```js
+export default defineConfig(
+  {
+    plugins: {
+      'fp-ts': fptsPlugin,
+    },
+
+    extends: ["fp-ts/all",]
+  }
+)
 ```

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "author": "buildo",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/buildo/eslint-plugin-fp-ts"
@@ -17,7 +18,9 @@
   "scripts": {
     "prepare": "npm run build",
     "preversion": "yarn lint && yarn test && yarn build",
+    "declarations": "tsc -p ./tsconfig.declaration.json",
     "build": "rimraf lib && yarn tsc",
+    "postbuild": "yarn declarations",
     "pretest": "yarn --cwd tests/fixtures/fp-ts-project install",
     "test": "jest",
     "lint": "eslint src/**/*.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-fp-ts",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "fp-ts ESLint rules",
   "keywords": [
     "eslint",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { array, record, semigroup } from "fp-ts";
 import { pipe } from "fp-ts/function";
+import {ESLint} from 'eslint'
 
 const potentialErrors = {
   "no-lib-imports": require("./rules/no-lib-imports").default,
@@ -16,12 +17,53 @@ const suggestions = {
   "prefer-bimap": require("./rules/prefer-bimap").default,
 };
 
-export const rules = {
+const pkg = require('../package.json');
+
+
+export const meta: ESLint.Plugin["meta"] & {namespace?: string} = {
+  name: pkg.name,
+  version: pkg.version,
+  namespace: 'fp-ts'
+}
+
+export const rules: ESLint.Plugin["rules"] = {
   ...potentialErrors,
   ...suggestions,
 };
 
-export const configs = {
+export const configs: ESLint.Plugin["configs"] = {};
+
+const plugin: ESLint.Plugin = {
+  meta,
+  rules,
+  configs
+}
+
+// assign configs here so we can reference `plugin`
+Object.assign(configs, {
+  // flat config format
+  "flat/recommended": {
+    plugins: {"fp-ts": plugin},
+    rules: {
+      "fp-ts/no-lib-imports": "error",
+      "fp-ts/no-pipeable": "error",
+    },
+  },
+  "flat/recommended-requiring-type-checking": {
+    plugins: {"fp-ts": plugin},
+    rules: {
+      "fp-ts/no-discarded-pure-expression": "error",
+    },
+  },
+  "flat/all": {
+    plugins: {"fp-ts": plugin},
+    rules: {
+      ...configuredRules(potentialErrors, "error"),
+      ...configuredRules(suggestions, "warn"),
+    },
+  },
+  
+  // eslintrc format
   recommended: {
     plugins: ["fp-ts"],
     rules: {
@@ -42,7 +84,9 @@ export const configs = {
       ...configuredRules(suggestions, "warn"),
     },
   },
-};
+});
+
+export default plugin
 
 function configuredRules(
   rules: Record<string, unknown>,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,6 @@ const suggestions = {
 
 const pkg = require('../package.json');
 
-
 export const meta: ESLint.Plugin["meta"] & {namespace?: string} = {
   name: pkg.name,
   version: pkg.version,

--- a/tsconfig.declaration.json
+++ b/tsconfig.declaration.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true
+  },
+  "include": ["src/index.ts"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1008,11 +1008,6 @@ ast-types@^0.16.1:
   dependencies:
     tslib "^2.0.1"
 
-async@^3.2.3:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
-  integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
-
 babel-jest@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.7.0.tgz#f4369919225b684c56085998ac63dbd05be020d5"
@@ -1113,13 +1108,6 @@ browserslist@^4.24.0:
     node-releases "^2.0.19"
     update-browserslist-db "^1.1.1"
 
-bs-logger@^0.2.6:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/bs-logger/-/bs-logger-0.2.6.tgz#eb7d365307a72cf974cc6cda76b68354ad336bd8"
-  integrity sha512-pd8DCoxmbgc7hyPKOvxtqNcjYoOsABPQdcCUjGp3d42VR2CX1ORhk2A87oqqu5R1kk+76nsxZupkmyd+MVtCog==
-  dependencies:
-    fast-json-stable-stringify "2.x"
-
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -1152,7 +1140,7 @@ caniuse-lite@^1.0.30001688:
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001701.tgz#ad9c90301f7153cf6b3314d16cc30757285bf9e7"
   integrity sha512-faRs/AW3jA9nTwmJBSO1PQ6L/EOgsB5HMQQq4iCu5zhPgVVgO/pZRHlmatwijZKetFw8/Pr4q6dEN8sJuq8qTw==
 
-chalk@^4.0.0, chalk@^4.0.2:
+chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -1279,13 +1267,6 @@ eastasianwidth@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/eastasianwidth/-/eastasianwidth-0.2.0.tgz#696ce2ec0aa0e6ea93a397ffcf24aa7840c827cb"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
-
-ejs@^3.1.10:
-  version "3.1.10"
-  resolved "https://registry.yarnpkg.com/ejs/-/ejs-3.1.10.tgz#69ab8358b14e896f80cc39e62087b88500c3ac3b"
-  integrity sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==
-  dependencies:
-    jake "^10.8.5"
 
 electron-to-chromium@^1.5.73:
   version "1.5.109"
@@ -1476,7 +1457,7 @@ fast-glob@^3.3.2:
     merge2 "^1.3.0"
     micromatch "^4.0.8"
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
+fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
@@ -1506,13 +1487,6 @@ file-entry-cache@^8.0.0:
   integrity sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==
   dependencies:
     flat-cache "^4.0.0"
-
-filelist@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/filelist/-/filelist-1.0.4.tgz#f78978a1e944775ff9e62e744424f215e58352b5"
-  integrity sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==
-  dependencies:
-    minimatch "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -1821,16 +1795,6 @@ jackspeak@^4.0.1:
   dependencies:
     "@isaacs/cliui" "^8.0.2"
 
-jake@^10.8.5:
-  version "10.9.2"
-  resolved "https://registry.yarnpkg.com/jake/-/jake-10.9.2.tgz#6ae487e6a69afec3a5e167628996b59f35ae2b7f"
-  integrity sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==
-  dependencies:
-    async "^3.2.3"
-    chalk "^4.0.2"
-    filelist "^1.0.4"
-    minimatch "^3.1.2"
-
 jest-changed-files@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-29.7.0.tgz#1c06d07e77c78e1585d020424dedc10d6e17ac3a"
@@ -2131,7 +2095,7 @@ jest-snapshot@^29.7.0:
     pretty-format "^29.7.0"
     semver "^7.5.3"
 
-jest-util@^29.0.0, jest-util@^29.7.0:
+jest-util@^29.7.0:
   version "29.7.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.7.0.tgz#23c2b62bfb22be82b44de98055802ff3710fc0bc"
   integrity sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==
@@ -2288,11 +2252,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.memoize@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-  integrity sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==
-
 lodash.merge@4.6.2, lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
@@ -2316,11 +2275,6 @@ make-dir@^4.0.0:
   integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
   dependencies:
     semver "^7.5.3"
-
-make-error@^1.3.6:
-  version "1.3.6"
-  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
-  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -2365,13 +2319,6 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
 
 minimatch@^9.0.4:
   version "9.0.5"
@@ -2662,7 +2609,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.1:
+semver@^7.5.3, semver@^7.5.4, semver@^7.6.0:
   version "7.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
   integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
@@ -2844,21 +2791,6 @@ ts-api-utils@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-2.0.1.tgz#660729385b625b939aaa58054f45c058f33f10cd"
   integrity sha512-dnlgjFSVetynI8nzgJ+qF62efpglpWRk8isUEWZGWlJYySCTD6aKvbUDu+zbPeDakk3bg5H4XpitHukgfL1m9w==
-
-ts-jest@^29.2.6:
-  version "29.2.6"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.2.6.tgz#df53edf8b72fb89de032cfa310abf37582851d9a"
-  integrity sha512-yTNZVZqc8lSixm+QGVFcPe6+yj7+TWZwIesuOWvfcn4B9bz5x4NDzVCQQjOs7Hfouu36aEqfEbo9Qpo+gq8dDg==
-  dependencies:
-    bs-logger "^0.2.6"
-    ejs "^3.1.10"
-    fast-json-stable-stringify "^2.1.0"
-    jest-util "^29.0.0"
-    json5 "^2.2.3"
-    lodash.memoize "^4.1.2"
-    make-error "^1.3.6"
-    semver "^7.7.1"
-    yargs-parser "^21.1.1"
 
 tslib@^2.0.1:
   version "2.8.1"


### PR DESCRIPTION
This PR makes the plugin compliant to the new format (ESLint v9) which is supported by `defineConfig()` utility.

References:
- https://eslint.org/blog/2025/03/flat-config-extends-define-config-global-ignores/#introducing-defineconfig()-for-eslint
- https://eslint.org/docs/latest/extend/plugins#backwards-compatibility-for-legacy-configs