### PR TITLE
Add npm support metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,10 @@
     "type": "git",
     "url": "https://github.com/buildo/eslint-plugin-fp-ts"
   },
+  "homepage": "https://github.com/buildo/eslint-plugin-fp-ts#readme",
+  "bugs": {
+    "url": "https://github.com/buildo/eslint-plugin-fp-ts/issues"
+  },
   "scripts": {
     "prepare": "npm run build",
     "preversion": "yarn lint && yarn test && yarn build",


### PR DESCRIPTION
Adds standard npm support links for the package:\n\n- homepage points to the README\n- bugs.url points to the GitHub issue tracker\n\nThis is a metadata-only change; runtime code and dependencies are unchanged.\n\nValidation:\n- yarn install --frozen-lockfile --ignore-scripts\n- yarn build\n- npm pack --dry-run\n- git diff --check